### PR TITLE
hotfix: resolve async problems

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 pythonpath = ./src
 log_cli=True
 log_cli_level=30
+asyncio_mode=auto

--- a/src/auth/spotify.py
+++ b/src/auth/spotify.py
@@ -9,12 +9,12 @@ from src.auth.utils import get_secrets
 from src.data.spotify import create
 from src.data.spotify import get_the_last_token
 from src.models.spotify import SpotifyTokensModel
-
+from sqlalchemy.ext.asyncio import AsyncSession
 secrets = get_secrets()
 
 
-async def get_spotify_client() -> spotipy.Spotify | None:
-    last_token = await get_the_last_token()
+async def get_spotify_client(db_session: AsyncSession) -> spotipy.Spotify | None:
+    last_token = await get_the_last_token(db_session)
     access_token = last_token.access_token
 
     if access_token is None:

--- a/src/data/core.py
+++ b/src/data/core.py
@@ -1,0 +1,7 @@
+from typing import Annotated
+
+from src.data.utils import get_db_session
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+DBSessionDep = Annotated[AsyncSession, Depends(get_db_session)]

--- a/src/data/spotify.py
+++ b/src/data/spotify.py
@@ -2,9 +2,9 @@ from datetime import datetime, timezone
 
 from openai import OpenAI
 from sqlalchemy.sql import select
-
+from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth.utils import get_config, get_secrets
-from src.data.utils import db
+from src.data.utils import sessionmanager
 from src.models.spotify import SpotifyTokensModel, SpotifyTokensOrm
 
 secrets = get_secrets()
@@ -19,15 +19,15 @@ client = OpenAI(
 async def create(token_info: SpotifyTokensModel) -> SpotifyTokensModel:
     sp_orm = SpotifyTokensOrm(**token_info.model_dump())
 
-    async with db.session_scope() as session:
+    async with sessionmanager.session_scope() as session:
         session.add(sp_orm)
         return SpotifyTokensModel.model_validate(sp_orm)
 
 
-async def get_the_last_token() -> SpotifyTokensModel:
-    async with db.session_scope() as session:
-        query = select(SpotifyTokensOrm).order_by(SpotifyTokensOrm.created_at.desc()).limit(1)
-        result = (await session.execute(query)).scalar_one_or_none()
-        token_info = SpotifyTokensModel.model_validate(result)
+async def get_the_last_token(db_session: AsyncSession) -> SpotifyTokensModel:
+
+    query = select(SpotifyTokensOrm).order_by(SpotifyTokensOrm.created_at.desc()).limit(1)
+    result = (await db_session.execute(query)).scalar_one_or_none()
+    token_info = SpotifyTokensModel.model_validate(result)
 
     return token_info

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -3,8 +3,10 @@ from contextlib import asynccontextmanager
 
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError, TimeoutError
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import (
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from src.auth.utils import get_secrets
 
@@ -30,7 +32,7 @@ class DatabaseSession:
 
     def __init__(self):
         self.engine = create_async_engine(DB_CONFIG, echo=False, future=True)
-        self.session = sessionmaker(self.engine, expire_on_commit=True, class_=AsyncSession)
+        self.session = async_sessionmaker(expire_on_commit=True, bind=self.engine)
 
     @asynccontextmanager
     async def session_scope(self):
@@ -46,4 +48,9 @@ class DatabaseSession:
             await session.close()
 
 
-db = DatabaseSession()
+sessionmanager = DatabaseSession()
+
+
+async def get_db_session():
+    async with sessionmanager.session_scope() as session:
+        yield session

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from fastapi import Depends, FastAPI, HTTPException, status
@@ -6,7 +5,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.auth.service import api_key_auth
 from src.auth.utils import get_config, get_secrets, setup_logging
-from src.data.utils import check_connection
 from src.routers import assistant_selector
 
 app = FastAPI(
@@ -54,19 +52,8 @@ async def root():
     return {"message": "Everything is fine."}
 
 
-async def initialize_app():
-    logging.info('Initializing application...')
-
-    from src.auth.spotify import get_spotify_client
-
-    logging.info('Check the necessary config...')
-    await get_spotify_client()
-    await check_connection()
-    logging.info('Application initialized')
-
-
 if __name__ == "__main__":
     import uvicorn
 
-    asyncio.run(initialize_app())
+    logging.info('App ready to accept requests...')
     uvicorn.run("main:app", reload=False, host="0.0.0.0", port=8080)

--- a/src/models/functions.py
+++ b/src/models/functions.py
@@ -13,6 +13,7 @@ class FunctionsAvailables(StrEnum):
 
 
 class FunctionPayload(BaseModel):
+    db_session: object = Field(..., description="Database session")
     thread_id: str = Field(..., description="Thread id")
     run_id: str = Field(..., description="Run id")
     function_id: str = Field(..., description="Function id given by OpenAI")

--- a/src/routers/assistant_selector.py
+++ b/src/routers/assistant_selector.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-
+from src.data.core import DBSessionDep
 from fastapi import APIRouter, Depends
 
 from src.auth.service import api_key_auth
@@ -20,9 +20,12 @@ router = APIRouter(
     response_model_exclude_none=False,
     dependencies=[Depends(api_key_auth)]
 )
-async def get_all(payload: AssistantSelectorModel) -> ResponseSchema | ErrorResponseSchema:
+async def get_all(
+        payload: AssistantSelectorModel,
+        db_session: DBSessionDep,
+) -> ResponseSchema | ErrorResponseSchema:
     try:
-        result = await service.post_messages(payload)
+        result = await service.post_messages(db_session, payload)
         logging.info(result)
         return ResponseSchema(
             status_code=200,

--- a/src/service/assistant_selector.py
+++ b/src/service/assistant_selector.py
@@ -3,6 +3,8 @@ import logging
 import re
 from datetime import datetime
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from src.models.assistant_selector import AssistantSelectorModel
 from src.models.functions import FunctionPayload
 from src.service.functions import return_output_functions
@@ -11,8 +13,8 @@ from src.service.openai import get_assistants
 from src.service.threads import get_thread
 
 
-async def post_messages(payload: AssistantSelectorModel):
-    thread = await get_thread()
+async def post_messages(db_session: AsyncSession, payload: AssistantSelectorModel):
+    thread = await get_thread(db_session)
     assistant = get_assistants()['SiriSelectorAssistant']
 
     for message in payload.messages:
@@ -52,6 +54,7 @@ async def post_messages(payload: AssistantSelectorModel):
                 if function_call.type == 'function':
                     result_data = await return_output_functions(
                         FunctionPayload(
+                            db_session=db_session,
                             thread_id=thread.id,
                             run_id=run.id,
                             function_name=function_call.function.name,

--- a/src/service/functions.py
+++ b/src/service/functions.py
@@ -171,7 +171,7 @@ def search_specific_song(
 
 async def play_spotify_music(func_params: FunctionPayload, **kwargs: dict) -> FunctionResult:
     try:
-        sp_client = await get_spotify_client()
+        sp_client = await get_spotify_client(func_params.db_session)
         if sp_client is None:
             return FunctionResult(
                 function_id=func_params.function_id,

--- a/src/service/threads.py
+++ b/src/service/threads.py
@@ -1,7 +1,8 @@
-import src.data.threads as threads
+from src.data.threads import get_the_last_thread
+from src.data.core import DBSessionDep
 from src.models.threads import ThreadsModel
 
 
-async def get_thread() -> ThreadsModel:
-    thread = await threads.get_the_last_thread()
+async def get_thread(db_session: DBSessionDep) -> ThreadsModel:
+    thread = await get_the_last_thread(db_session)
     return thread


### PR DESCRIPTION
1. Update pytest.ini to include asyncio_mode=auto.
2. Refactor get_spotify_client function in spotify.py to accept a db_session parameter.
3. Add core.py for DBSessionDep annotation. Modify create and get_the_last_token functions in data/spotify.py to use sessionmanager instead of db.
4. Update threads.py functions to accept db_session parameter and use sessionmanager for session management. Introduce DatabaseSession class in data/utils.py with async context manager for session_scope.
5. Adjust main.py logging and remove unused imports. Include db_session parameter in FunctionPayload model in models/functions.py.
6. Modify assistant_selector router to include DBSessionDep dependency and pass db_session to service.post_messages function in assistant_selector.py router file.
7. Add fixture for db_session setup in service/__tests__/functions.py tests, update test_open_pycharm_projects and test_spotify_basic_search_artist functions to pass db_session parameter, and adjust imports accordingly.
